### PR TITLE
by default, remoting.context is false

### DIFF
--- a/src/loopback-config.json
+++ b/src/loopback-config.json
@@ -40,7 +40,10 @@
           "default": "false"
         },
         "context" : {
-          "type": "object",
+          "type": [
+            "boolean",
+            "object"
+          ],
           "properties" : {
             "enableHttpContext" : {
               "type":"boolean",


### PR DESCRIPTION
`remoting.context` can be either a boolean (false) or an object

[from the doc](https://loopback.io/doc/en/lb2/Using-current-context.html)

    > To remove this warning, disable the context middleware added by the built-in REST handler. Set the remoting.context property in server/config.json to false; for example: